### PR TITLE
Add third-party oauth2 authorization system. Close #48

### DIFF
--- a/chronicle-etl.gemspec
+++ b/chronicle-etl.gemspec
@@ -40,10 +40,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "~> 7.0"
   spec.add_dependency "chronic_duration", "~> 0.10.6"
   spec.add_dependency "colorize", "~> 0.8.1"
+  spec.add_dependency 'launchy'
   spec.add_dependency "marcel", "~> 1.0.2"
   spec.add_dependency "mini_exiftool", "~> 2.10"
   spec.add_dependency "nokogiri", "~> 1.13"
+  spec.add_dependency 'omniauth'
+  spec.add_dependency 'omniauth-google-oauth2'
   spec.add_dependency "sequel", "~> 5.35"
+  spec.add_dependency 'sinatra'
   spec.add_dependency "sqlite3", "~> 1.4"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "thor-hollaback", "~> 0.2"
@@ -54,8 +58,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "xdg", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "guard-rspec", "~> 4.7.3"
   spec.add_development_dependency "fakefs"
+  spec.add_development_dependency "guard-rspec", "~> 4.7.3"
   spec.add_development_dependency "pry-byebug", "~> 3.9"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.9"

--- a/chronicle-etl.gemspec
+++ b/chronicle-etl.gemspec
@@ -44,10 +44,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "marcel", "~> 1.0.2"
   spec.add_dependency "mini_exiftool", "~> 2.10"
   spec.add_dependency "nokogiri", "~> 1.13"
-  spec.add_dependency 'omniauth'
-  spec.add_dependency 'omniauth-google-oauth2'
+  spec.add_dependency 'omniauth', "~> 2"
   spec.add_dependency "sequel", "~> 5.35"
-  spec.add_dependency 'sinatra'
+  spec.add_dependency 'sinatra', "~> 2"
   spec.add_dependency "sqlite3", "~> 1.4"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "thor-hollaback", "~> 0.2"

--- a/lib/chronicle/etl.rb
+++ b/lib/chronicle/etl.rb
@@ -1,4 +1,5 @@
 require_relative 'etl/registry/registry'
+require_relative 'etl/authorizer'
 require_relative 'etl/config'
 require_relative 'etl/configurable'
 require_relative 'etl/exceptions'

--- a/lib/chronicle/etl/authorization_server.rb
+++ b/lib/chronicle/etl/authorization_server.rb
@@ -21,19 +21,21 @@ module Chronicle
         set :sessions, true
         set :quiet, true
         set :threaded, true
-        set :environment, :production
+        set :environment, ENV['APP_ENV'] == 'test' ? :test : :production
       end
+
+      puts self.environment
 
       use OmniAuth::Builder do
         Chronicle::ETL::OauthAuthorizer.all_omniauth_strategies.each do |klass|
+          args = [klass.client_id, klass.client_secret, klass.options].compact
           provider(
             klass.strategy,
-            klass.client_id,
-            klass.client_secret,
-            klass.options
+            *args
           )
         end
       end
+
 
       OmniAuth.config.logger = Chronicle::ETL::Logger
       OmniAuth.config.silence_get_warning = true

--- a/lib/chronicle/etl/authorization_server.rb
+++ b/lib/chronicle/etl/authorization_server.rb
@@ -1,0 +1,53 @@
+require 'sinatra'
+require 'omniauth'
+
+module Chronicle
+  module ETL
+    class AuthorizationServer < Sinatra::Base
+      class << self
+        attr_accessor :latest_authorization
+
+        def initialize(*args)
+          @saved_authorization = false
+          super
+        end
+      end
+
+      configure do
+        set :inline_templates, true
+        set :dump_errors, false
+        set :raise_errors, true
+        disable :logging
+        set :sessions, true
+        set :quiet, true
+        set :threaded, true
+        set :environment, :production
+      end
+
+      use OmniAuth::Builder do
+        Chronicle::ETL::OauthAuthorizer.all_omniauth_strategies.each do |klass|
+          provider(
+            klass.strategy,
+            klass.client_id,
+            klass.client_secret,
+            klass.options
+          )
+        end
+      end
+
+      OmniAuth.config.logger = Chronicle::ETL::Logger
+      OmniAuth.config.silence_get_warning = true
+      OmniAuth.config.allowed_request_methods = %i[get]
+
+      get '/auth/:provider/callback' do
+        authorization = request.env['omniauth.auth'].to_h.deep_transform_keys(&:to_sym)
+        self.class.latest_authorization = authorization
+        erb "<h1>Settings saved for #{params[:provider]}</h1><p>You can now close this tab and return to your terminal!</p>"
+      end
+
+      get '/auth/failure' do
+        erb "<h1>Authentication Failed:</h1><h3>message:<h3> <pre>#{params}</pre>"
+      end
+    end
+  end
+end

--- a/lib/chronicle/etl/authorization_server.rb
+++ b/lib/chronicle/etl/authorization_server.rb
@@ -24,8 +24,6 @@ module Chronicle
         set :environment, ENV['APP_ENV'] == 'test' ? :test : :production
       end
 
-      puts self.environment
-
       use OmniAuth::Builder do
         Chronicle::ETL::OauthAuthorizer.all_omniauth_strategies.each do |klass|
           args = [klass.client_id, klass.client_secret, klass.options].compact
@@ -35,7 +33,6 @@ module Chronicle
           )
         end
       end
-
 
       OmniAuth.config.logger = Chronicle::ETL::Logger
       OmniAuth.config.silence_get_warning = true
@@ -48,6 +45,7 @@ module Chronicle
       end
 
       get '/auth/failure' do
+        # TODO: handle this
         erb "<h1>Authentication Failed:</h1><h3>message:<h3> <pre>#{params}</pre>"
       end
     end

--- a/lib/chronicle/etl/authorization_server.rb
+++ b/lib/chronicle/etl/authorization_server.rb
@@ -6,11 +6,6 @@ module Chronicle
     class AuthorizationServer < Sinatra::Base
       class << self
         attr_accessor :latest_authorization
-
-        def initialize(*args)
-          @saved_authorization = false
-          super
-        end
       end
 
       configure do
@@ -25,7 +20,7 @@ module Chronicle
       end
 
       use OmniAuth::Builder do
-        Chronicle::ETL::OauthAuthorizer.all_omniauth_strategies.each do |klass|
+        Chronicle::ETL::OauthAuthorizer.all.each do |klass|
           args = [klass.client_id, klass.client_secret, klass.options].compact
           provider(
             klass.strategy,

--- a/lib/chronicle/etl/authorizer.rb
+++ b/lib/chronicle/etl/authorizer.rb
@@ -30,21 +30,6 @@ module Chronicle
       def authorize!
         raise NotImplementedError
       end
-
-      private
-
-      def load_credentials(source)
-        namespace = source || default_credentials_source
-        unless Chronicle::ETL::Secrets.exists?(namespace)
-          raise(AuthorizationError.new, "Oauth credentials specified as '#{source}' but a secrets namespace with that name does not exist.")
-        end
-
-        Chronicle::ETL::Secrets.read(namespace)
-      end
-
-      def default_credentials_source
-        self.class.provider_name
-      end
     end
   end
 end

--- a/lib/chronicle/etl/authorizer.rb
+++ b/lib/chronicle/etl/authorizer.rb
@@ -1,0 +1,25 @@
+module Chronicle
+  module ETL
+    class Authorizer
+      class << self
+        attr_reader :provider_name
+
+        def provider(provider_name)
+          @provider_name = provider_name
+        end
+
+        def find_by_provider(provider)
+          ObjectSpace.each_object(::Class).select {|klass| klass < self }.find do |authorizer|
+            authorizer.provider_name == provider
+          end
+        end
+      end
+
+      def load_credentials
+        Chronicle::ETL::Secrets.read(self.class.provider_name)
+      end
+    end
+  end
+end
+
+require_relative 'oauth_authorizer'

--- a/lib/chronicle/etl/authorizer.rb
+++ b/lib/chronicle/etl/authorizer.rb
@@ -15,6 +15,13 @@ module Chronicle
         end
       end
 
+      def initialize(args)
+      end
+
+      def authorize!
+        raise NotImplementedError
+      end
+
       def load_credentials
         Chronicle::ETL::Secrets.read(self.class.provider_name)
       end

--- a/lib/chronicle/etl/authorizer.rb
+++ b/lib/chronicle/etl/authorizer.rb
@@ -1,13 +1,20 @@
 module Chronicle
   module ETL
+    # An authorization strategy for a third-party data source
     class Authorizer
       class << self
         attr_reader :provider_name
 
+        # Macro for setting provider on an Authorizer
         def provider(provider_name)
           @provider_name = provider_name
         end
 
+        # From all loaded Authorizers, return the first one that matches
+        # a given provider
+        #
+        # @todo Have a proper identifier system for authorizers
+        #   (to have more than one per plugin)
         def find_by_provider(provider)
           ObjectSpace.each_object(::Class).select {|klass| klass < self }.find do |authorizer|
             authorizer.provider_name == provider
@@ -15,15 +22,28 @@ module Chronicle
         end
       end
 
+      # Construct a new authorizer
       def initialize(args)
       end
 
+      # Main entry-point for authorization flows. Implemented by subclass
       def authorize!
         raise NotImplementedError
       end
 
-      def load_credentials
-        Chronicle::ETL::Secrets.read(self.class.provider_name)
+      private
+
+      def load_credentials(source)
+        namespace = source || default_credentials_source
+        unless Chronicle::ETL::Secrets.exists?(namespace)
+          raise(AuthorizationError.new, "Oauth credentials specified as '#{source}' but a secrets namespace with that name does not exist.")
+        end
+
+        Chronicle::ETL::Secrets.read(namespace)
+      end
+
+      def default_credentials_source
+        self.class.provider_name
       end
     end
   end

--- a/lib/chronicle/etl/cli.rb
+++ b/lib/chronicle/etl/cli.rb
@@ -4,6 +4,7 @@ require 'chronicle/etl'
 
 require 'chronicle/etl/cli/cli_base'
 require 'chronicle/etl/cli/subcommand_base'
+require 'chronicle/etl/cli/authorizations'
 require 'chronicle/etl/cli/connectors'
 require 'chronicle/etl/cli/jobs'
 require 'chronicle/etl/cli/plugins'

--- a/lib/chronicle/etl/cli/authorizations.rb
+++ b/lib/chronicle/etl/cli/authorizations.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'sinatra'
+require 'launchy'
+require 'pp'
+
+module Chronicle
+  module ETL
+    module CLI
+      # CLI commands for authorizing chronicle-etl with third-party services
+      class Authorizations < SubcommandBase
+        default_task 'new'
+        namespace :authorizations
+
+        desc "authorize", "Authorize with a third-party provider"
+        option :port, desc: 'Port to run authorization server on', type: :numeric, default: 4567
+        option :credentials, desc: 'Secrets namespace for where to read credentials from (default: PROVIDER)', type: :string, banner: 'NAMESPACE'
+        option :secrets, desc: 'Secrets namespace for where authorization should be saved to (default: PROVIDER)', type: :string, banner: 'NAMESPACE'
+        option :print, desc: 'Show authorization results (instead of just saving secrets)', type: :boolean, default: false
+        def authorize(provider)
+          # TODO: this assumes provider:plugin one-to-one
+          unless Chronicle::ETL::Registry::PluginRegistry.installed?(provider)
+            cli_fail(message: "Plugin for #{provider} is not installed.")
+          end
+
+          begin
+            require "chronicle/#{provider}"
+          rescue LoadError => e
+            cli_fail(message: "Could not load plugin '#{provider}'.\n" + e.message, exception: e)
+          end
+
+          authorizer_klass = Authorizer.find_by_provider(provider.to_sym)
+          authorizer = authorizer_klass.new(port: options[:port])
+
+          authorizer.authorize!
+          secrets = authorizer.secrets
+
+          namespace = options[:secrets] || provider
+          Chronicle::ETL::Secrets.set_all(namespace, secrets)
+
+          pp secrets if options[:print]
+
+          cli_exit(message: "Authorization saved to '#{namespace}' secrets")
+        rescue StandardError => e
+          cli_fail(message: "Authorization not successful.\n" + e.message, exception: e)
+        end
+      end
+    end
+  end
+end

--- a/lib/chronicle/etl/cli/authorizations.rb
+++ b/lib/chronicle/etl/cli/authorizations.rb
@@ -24,16 +24,15 @@ module Chronicle
           end
 
           begin
-            require "chronicle/#{provider}"
-          rescue LoadError => e
+            Chronicle::ETL::Registry::PluginRegistry.activate(provider)
+          rescue PluginError => e
             cli_fail(message: "Could not load plugin '#{provider}'.\n" + e.message, exception: e)
           end
 
           authorizer_klass = Authorizer.find_by_provider(provider.to_sym)
           authorizer = authorizer_klass.new(port: options[:port])
 
-          authorizer.authorize!
-          secrets = authorizer.secrets
+          secrets = authorizer.authorize!
 
           namespace = options[:secrets] || provider
           Chronicle::ETL::Secrets.set_all(namespace, secrets)

--- a/lib/chronicle/etl/cli/authorizations.rb
+++ b/lib/chronicle/etl/cli/authorizations.rb
@@ -17,7 +17,7 @@ module Chronicle
         option :credentials, desc: 'Secrets namespace for where to read credentials from (default: PROVIDER)', type: :string, banner: 'NAMESPACE'
         option :secrets, desc: 'Secrets namespace for where authorization should be saved to (default: PROVIDER)', type: :string, banner: 'NAMESPACE'
         option :print, desc: 'Show authorization results (instead of just saving secrets)', type: :boolean, default: false
-        def authorize(provider)
+        def new(provider)
           # TODO: this assumes provider:plugin one-to-one
           unless Chronicle::ETL::Registry::PluginRegistry.installed?(provider)
             cli_fail(message: "Plugin for #{provider} is not installed.")
@@ -30,7 +30,9 @@ module Chronicle
           end
 
           authorizer_klass = Authorizer.find_by_provider(provider.to_sym)
-          authorizer = authorizer_klass.new(port: options[:port])
+          cli_fail(message: "An authorizer for '#{provider}' could not be found.") unless authorizer_klass
+
+          authorizer = authorizer_klass.new(port: options[:port], credentials: options[:credentials])
 
           secrets = authorizer.authorize!
 

--- a/lib/chronicle/etl/cli/cli_base.rb
+++ b/lib/chronicle/etl/cli/cli_base.rb
@@ -6,7 +6,10 @@ module Chronicle
         no_commands do
           # Shorthand for cli_exit(status: :failure)
           def cli_fail(message: nil, exception: nil)
-            message += "\nRe-run the command with --verbose to see details." if Chronicle::ETL::Logger.log_level > Chronicle::ETL::Logger::DEBUG
+            if exception && Chronicle::ETL::Logger.log_level > Chronicle::ETL::Logger::DEBUG
+              message += "\nRe-run the command with --verbose to see details."
+            end
+
             cli_exit(status: :failure, message: message, exception: exception)
           end
 

--- a/lib/chronicle/etl/cli/main.rb
+++ b/lib/chronicle/etl/cli/main.rb
@@ -27,6 +27,9 @@ module Chronicle
         desc 'secrets:COMMAND', 'Manage secrets', hide: true
         subcommand 'secrets', Secrets
 
+        desc 'authorizations', 'Authorize', hide: true
+        subcommand 'authorizations', Authorizations
+
         # Entrypoint for the CLI
         def self.start(given_args = ARGV, config = {})
           # take a subcommand:command and splits them so Thor knows how to hand off to the subcommand class

--- a/lib/chronicle/etl/exceptions.rb
+++ b/lib/chronicle/etl/exceptions.rb
@@ -4,6 +4,8 @@ module Chronicle
 
     class SecretsError < Error; end
 
+    class AuthorizationError < Error; end
+
     class ConfigError < Error; end
 
     class RunnerError < Error; end

--- a/lib/chronicle/etl/logger.rb
+++ b/lib/chronicle/etl/logger.rb
@@ -17,8 +17,8 @@ module Chronicle
       def output message, level
         return unless level >= @log_level
 
-        if @progress_bar
-          @progress_bar.log(message)
+        if @ui_element
+          @ui_element.log(message)
         else
           $stderr.puts(message)
         end
@@ -40,12 +40,12 @@ module Chronicle
         output(message, DEBUG)
       end
 
-      def attach_to_progress_bar(progress_bar)
-        @progress_bar = progress_bar
+      def attach_to_ui(ui_element)
+        @ui_elemenet = ui_element
       end
 
-      def detach_from_progress_bar
-        @progress_bar = nil
+      def detach_from_ui
+        @ui_element = nil
       end
     end
   end

--- a/lib/chronicle/etl/oauth_authorizer.rb
+++ b/lib/chronicle/etl/oauth_authorizer.rb
@@ -32,13 +32,12 @@ module Chronicle
       def initialize(port: )
         @port = port
         @credentials = load_credentials
-        super()
+        super
       end
 
       def authorize!
         associate_oauth_credentials
         @server = load_server
-
         spinner = TTY::Spinner.new(":spinner :title", format: :dots_2)
         spinner.auto_spin
         spinner.update(title: "Starting temporary authorization server on port #{@port}""")
@@ -47,9 +46,7 @@ module Chronicle
         start_oauth_flow
 
         spinner.update(title: "Waiting for authorization to complete in your browser")
-        while server_thread.status && !@server.latest_authorization
-          sleep 0.5
-        end
+        sleep 0.1 while authorization_pending?(server_thread)
 
         @server.quit!
         server_thread.join
@@ -61,6 +58,10 @@ module Chronicle
       end
 
       private
+
+      def authorization_pending?(server_thread)
+        server_thread.status && !@server.latest_authorization
+      end
 
       def associate_oauth_credentials
         self.class.client_id = @credentials[:client_id]

--- a/lib/chronicle/etl/oauth_authorizer.rb
+++ b/lib/chronicle/etl/oauth_authorizer.rb
@@ -39,9 +39,9 @@ module Chronicle
       attr_reader :authorization
 
       # Create a new instance of OauthAuthorizer
-      def initialize(port:, credentials: nil)
+      def initialize(port:, credentials: {})
         @port = port
-        @credentials = load_credentials(credentials)
+        @credentials = credentials
         super
       end
 
@@ -107,6 +107,8 @@ module Chronicle
       def start_oauth_flow
         url = "http://localhost:#{@port}/auth/#{omniauth_strategy}"
         Launchy.open(url)
+      rescue Launchy::CommandNotFoundError
+        Chronicle::ETL::Logger.info("Please open #{url} in a browser to continue")
       end
 
       def suppress_webrick_logging(server)

--- a/lib/chronicle/etl/oauth_authorizer.rb
+++ b/lib/chronicle/etl/oauth_authorizer.rb
@@ -56,10 +56,6 @@ module Chronicle
         spinner.success("(#{'successful'.green})")
 
         @authorization = @server.latest_authorization
-      end
-
-      def secrets
-        raise "Call authorize! before trying to get secrets" unless @authorization
 
         extract_secrets(self.class.authorization_to_secret_map, @authorization)
       end

--- a/lib/chronicle/etl/oauth_authorizer.rb
+++ b/lib/chronicle/etl/oauth_authorizer.rb
@@ -1,0 +1,129 @@
+require 'omniauth'
+require 'tty-spinner'
+
+module Chronicle
+  module ETL
+    class OauthAuthorizer < Authorizer
+      class << self
+        attr_reader :strategy, :options, :provider_name, :authorization_to_secret_map
+        attr_accessor :client_id, :client_secret
+
+        def omniauth_strategy(strategy)
+          @strategy = strategy
+        end
+
+        def scope(value)
+          options[:scope] = value
+        end
+
+        def pluck_secrets(map)
+          @authorization_to_secret_map = map
+        end
+
+        def options
+          @options ||= {}
+        end
+
+        def all_omniauth_strategies
+          ObjectSpace.each_object(::Class).select { |klass| klass < self }
+        end
+      end
+
+      def initialize(port: )
+        @port = port
+        @credentials = load_credentials
+        super()
+      end
+
+      def authorize!
+        associate_oauth_credentials
+        @server = load_server
+
+        spinner = TTY::Spinner.new(":spinner :title", format: :dots_2)
+        spinner.auto_spin
+        spinner.update(title: "Starting temporary authorization server on port #{@port}""")
+
+        server_thread = start_authorization_server(port: @port)
+        start_oauth_flow
+
+        spinner.update(title: "Waiting for authorization to complete in your browser")
+        while server_thread.status && !@server.latest_authorization
+          sleep 0.5
+        end
+
+        @server.quit!
+        server_thread.join
+        spinner.success("(#{'successful'.green})")
+
+        @authorization = @server.latest_authorization
+      end
+
+      def secrets
+        raise "Call authorize! before trying to get secrets" unless @authorization
+
+        extract_secrets(self.class.authorization_to_secret_map, @authorization)
+      end
+
+      private
+
+      def associate_oauth_credentials
+        self.class.client_id = @credentials[:client_id]
+        self.class.client_secret = @credentials[:client_secret]
+      end
+
+      def load_server
+        # Load at runtime so that we can set omniauth strategies based on
+        # which chronicle plugin has been loaded.
+        require_relative './authorization_server'
+        Chronicle::ETL::AuthorizationServer
+      end
+
+      def start_authorization_server(port:)
+        @server.settings.port = port
+        suppress_webrick_logging(@server)
+        Thread.abort_on_exception = true
+        Thread.report_on_exception = false
+
+        Thread.new do
+          @server.run!({ port: @port }) do |s|
+            s.silent = true if s.class.to_s == "Thin::Server"
+          end
+        end
+      end
+
+      def start_oauth_flow
+        url = "http://localhost:#{@port}/auth/#{omniauth_strategy}"
+        Launchy.open(url)
+      end
+
+      def suppress_webrick_logging(server)
+        require 'webrick'
+        server.set(
+          :server_settings,
+          {
+            AccessLog: [],
+            # TODO: make this windows friendly
+            # https://github.com/winton/stasis/commit/77da36f43285fda129300e382f18dfaff48571b0
+            Logger: WEBrick::Log::new("/dev/null")
+          }
+        )
+      rescue LoadError
+        # no worries if we're not using WEBrick
+      end
+
+      def extract_secrets(map, authorization)
+        map.each_with_object({}) do |(key, identifiers), secrets|
+          secrets[key] = authorization.dig(*identifiers)
+        end
+      end
+
+      def provider
+        self.class.provider_name
+      end
+
+      def omniauth_strategy
+        self.class.strategy
+      end
+    end
+  end
+end

--- a/lib/chronicle/etl/registry/plugin_registry.rb
+++ b/lib/chronicle/etl/registry/plugin_registry.rb
@@ -11,6 +11,16 @@ module Chronicle
       # @todo Better validation for whether a gem is actually a plugin
       # @todo Add ways to load a plugin that don't require a gem on rubygems.org
       module PluginRegistry
+        class << self
+          def register_standalone(name)
+            standalones << name
+          end
+
+          def standalones
+            @standalones ||= []
+          end
+        end
+
         # Does this plugin exist?
         def self.exists?(name)
           # TODO: implement this. Could query rubygems.org or use a hardcoded
@@ -34,7 +44,7 @@ module Chronicle
         # Check whether a given plugin is installed
         def self.installed?(name)
           gem_name = "chronicle-#{name}"
-          all_installed.map(&:name).include?(gem_name)
+          all_installed.map(&:name).include?(gem_name) || self.standalones.include?(name)
         end
 
         # Activate a plugin with given name by `require`ing it

--- a/lib/chronicle/etl/registry/plugin_registry.rb
+++ b/lib/chronicle/etl/registry/plugin_registry.rb
@@ -12,6 +12,8 @@ module Chronicle
       # @todo Add ways to load a plugin that don't require a gem on rubygems.org
       module PluginRegistry
         class << self
+          # Start of a system for having non-gem plugins. Right now, we just
+          # make registry aware of existenc of name of non-gem plugin
           def register_standalone(name)
             standalones << name
           end
@@ -43,8 +45,7 @@ module Chronicle
 
         # Check whether a given plugin is installed
         def self.installed?(name)
-          gem_name = "chronicle-#{name}"
-          all_installed.map(&:name).include?(gem_name) || self.standalones.include?(name)
+          (standalones + all_installed.map { |gem| gem.name.gsub("chronicle-", "") }).include?(name)
         end
 
         # Activate a plugin with given name by `require`ing it

--- a/lib/chronicle/etl/runner.rb
+++ b/lib/chronicle/etl/runner.rb
@@ -63,7 +63,7 @@ class Chronicle::ETL::Runner
   def prepare_ui
     total = @extractor.results_count
     @progress_bar = Chronicle::ETL::Utils::ProgressBar.new(title: 'Running job', total: total)
-    Chronicle::ETL::Logger.attach_to_progress_bar(@progress_bar)
+    Chronicle::ETL::Logger.attach_to_ui(@progress_bar)
   end
 
   def run_extraction
@@ -99,7 +99,7 @@ class Chronicle::ETL::Runner
   def finish_job
     @job_logger.save
     @progress_bar&.finish
-    Chronicle::ETL::Logger.detach_from_progress_bar
+    Chronicle::ETL::Logger.detach_from_ui
     Chronicle::ETL::Logger.info(tty_log_completion)
   end
 

--- a/lib/chronicle/etl/secrets.rb
+++ b/lib/chronicle/etl/secrets.rb
@@ -4,6 +4,11 @@ module Chronicle
     module Secrets
       module_function
 
+      # Whether a given namespace exists
+      def exists?(namespace)
+        Chronicle::ETL::Config.exists?("secrets", namespace)
+      end
+
       # Save a setting to a namespaced config file
       def set(namespace, key, value)
         config = read(namespace)
@@ -11,6 +16,7 @@ module Chronicle
         write(namespace, config)
       end
 
+      # Save a hash to a secrets namespace
       def set_all(namespace, secrets)
         config = read(namespace)
         config = config.merge(secrets)

--- a/lib/chronicle/etl/secrets.rb
+++ b/lib/chronicle/etl/secrets.rb
@@ -11,6 +11,12 @@ module Chronicle
         write(namespace, config)
       end
 
+      def set_all(namespace, secrets)
+        config = read(namespace)
+        config = config.merge(secrets)
+        write(namespace, config)
+      end
+
       # Remove a setting from a namespaced config file
       def unset(namespace, key)
         config = read(namespace)

--- a/spec/chronicle/etl/cli/authorizations_spec.rb
+++ b/spec/chronicle/etl/cli/authorizations_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Chronicle::ETL::CLI::Authorizations do
+  describe "#authorize" do
+    context "with an available plugin" do
+      before do
+        path = File.expand_path(File.join(RSPEC_ROOT, 'support/mock_plugins/chronicle-foo'))
+        $LOAD_PATH.unshift(path)
+        Chronicle::ETL::Registry::PluginRegistry.register_standalone('foo')
+      end
+
+      it "can authorize" do
+        FakeFS.with_fresh do
+          _, stderr = invoke_cli(%w[authorizations:authorize foo])
+
+          expect(Chronicle::ETL::Secrets.read('foo')).to eql({token: "abc"})
+        end
+      end
+
+      it "can print authorization results to stdout" do
+        FakeFS.with_fresh do
+          stdout, _ = invoke_cli(%w[authorizations:authorize foo --print])
+
+          expect(stdout).to match(/abc/)
+        end
+      end
+    end
+
+    context "for a plugin that's not installed" do
+      it "will exit with an error" do
+        expect do 
+          invoke_cli(%w[authorizations:authorize foobar123], false)
+        end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(1) }
+      end
+
+      it "will show an error message" do
+        _, stderr = invoke_cli(%w[authorizations:authorize foobar123])
+        expect(stderr.split("\n").map(&:uncolorize).first).to match(/is not installed/)
+      end
+    end
+  end
+end

--- a/spec/chronicle/etl/cli/authorizations_spec.rb
+++ b/spec/chronicle/etl/cli/authorizations_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe Chronicle::ETL::CLI::Authorizations do
       end
     end
 
+    context "for credentials specified that don't exist" do
+      it "will exit with an error" do
+        expect do 
+          invoke_cli(%w[authorizations:new foo --credentials fake123], false)
+        end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(1) }
+      end
+
+      it "will show an error message" do
+        _, stderr = invoke_cli(%w[authorizations:new foo --credentials fake123])
+        expect(stderr.split("\n").map(&:uncolorize).first).to match(/name does not exist/)
+      end
+    end
+
     context "for a plugin that can't be loaded" do
       it "will exit with an error" do
         expect do 
@@ -50,7 +63,7 @@ RSpec.describe Chronicle::ETL::CLI::Authorizations do
 
       it "will show an error message" do
         _, stderr = invoke_cli(%w[authorizations:new empty])
-        expect(stderr.split("\n").map(&:uncolorize).first).to match(/could not be found/)
+        expect(stderr.split("\n").map(&:uncolorize).first).to match(/No authorizer available/)
       end
     end
 

--- a/spec/chronicle/etl/cli/authorizations_spec.rb
+++ b/spec/chronicle/etl/cli/authorizations_spec.rb
@@ -1,17 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe Chronicle::ETL::CLI::Authorizations do
-  describe "#authorize" do
+  describe "#new" do
     context "with an available plugin" do
       before do
-        path = File.expand_path(File.join(RSPEC_ROOT, 'support/mock_plugins/chronicle-foo'))
-        $LOAD_PATH.unshift(path)
-        Chronicle::ETL::Registry::PluginRegistry.register_standalone('foo')
+        ['foo', 'empty', 'error'].each do |plugin|
+          path = File.expand_path(File.join(RSPEC_ROOT, "support/mock_plugins/chronicle-#{plugin}"))
+          $LOAD_PATH.unshift(path)
+          Chronicle::ETL::Registry::PluginRegistry.register_standalone(plugin)
+        end
       end
 
       it "can authorize" do
         FakeFS.with_fresh do
-          _, stderr = invoke_cli(%w[authorizations:authorize foo])
+          _, stderr = invoke_cli(%w[authorizations:new foo])
 
           expect(Chronicle::ETL::Secrets.read('foo')).to eql({token: "abc"})
         end
@@ -19,22 +21,48 @@ RSpec.describe Chronicle::ETL::CLI::Authorizations do
 
       it "can print authorization results to stdout" do
         FakeFS.with_fresh do
-          stdout, _ = invoke_cli(%w[authorizations:authorize foo --print])
+          stdout, _ = invoke_cli(%w[authorizations:new foo --print])
 
           expect(stdout).to match(/abc/)
         end
       end
     end
 
-    context "for a plugin that's not installed" do
+    context "for a plugin that can't be loaded" do
       it "will exit with an error" do
         expect do 
-          invoke_cli(%w[authorizations:authorize foobar123], false)
+          invoke_cli(%w[authorizations:new error], false)
         end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(1) }
       end
 
       it "will show an error message" do
-        _, stderr = invoke_cli(%w[authorizations:authorize foobar123])
+        _, stderr = invoke_cli(%w[authorizations:new error])
+        expect(stderr.split("\n").map(&:uncolorize).first).to match(/Could not load/)
+      end
+    end
+
+    context "for a plugin that doesn't have an authorizer" do
+      it "will exit with an error" do
+        expect do 
+          invoke_cli(%w[authorizations:new empty], false)
+        end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(1) }
+      end
+
+      it "will show an error message" do
+        _, stderr = invoke_cli(%w[authorizations:new empty])
+        expect(stderr.split("\n").map(&:uncolorize).first).to match(/could not be found/)
+      end
+    end
+
+    context "for a plugin that's not installed" do
+      it "will exit with an error" do
+        expect do 
+          invoke_cli(%w[authorizations:new foobar123], false)
+        end.to raise_error(SystemExit) { |exit| expect(exit.status).to be(1) }
+      end
+
+      it "will show an error message" do
+        _, stderr = invoke_cli(%w[authorizations:new foobar123])
         expect(stderr.split("\n").map(&:uncolorize).first).to match(/is not installed/)
       end
     end

--- a/spec/chronicle/etl/oauth_authorizer_spec.rb
+++ b/spec/chronicle/etl/oauth_authorizer_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+OmniAuth.config.test_mode = true
+OmniAuth.config.mock_auth[:developer] = {
+  token: 'abc'
+}
+# Make sure AuthorizationServer knows we're in test mode
+ENV['APP_ENV'] = 'test'
+
+# Prevent Launchy from attempt to open windows in oauth_authorizer.rb
+ENV['LAUNCHY_DRY_RUN'] = 'true'
+
+
+RSpec.describe Chronicle::ETL::OauthAuthorizer do
+  let(:port) { 5678 }
+  let(:authorizer) do
+    Class.new(Chronicle::ETL::OauthAuthorizer) do
+      provider :foo
+      omniauth_strategy :developer
+      scope 'email'
+      pluck_secrets({ token: [:token]})
+    end
+  end
+
+  before do
+    stub_const("FooAuthorizer", authorizer)
+  end
+
+  it "works" do
+    a = authorizer.new(port: port)
+    thread = Thread.new do
+      wait_until do
+        booted?
+      end
+      fetch("http://localhost:#{port}/auth/developer/")
+    end
+
+    result = suppress_output do
+      a.authorize!
+    end
+    thread.join
+    expect(result).to eql({ token: 'abc' })
+  end
+
+  def booted?
+    fetch("http://localhost:#{port}/")
+    true
+  rescue Errno::ECONNREFUSED, Errno::EBADF
+    false
+  end
+
+  # TODO: use library? put in SpecHelpers?
+  def fetch(uri, limit = 10)
+    response = Net::HTTP.get_response(URI(uri))
+    fetch(response['location'], limit - 1) if response == Net::HTTPRedirection || response.code == "302"
+  end
+end

--- a/spec/chronicle/etl/oauth_authorizer_spec.rb
+++ b/spec/chronicle/etl/oauth_authorizer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Chronicle::ETL::OauthAuthorizer do
     stub_const("FooAuthorizer", authorizer)
   end
 
-  it "works" do
+  it "returs an authorization after oauth flow completed" do
     a = authorizer.new(port: port)
     thread = Thread.new do
       wait_until do
@@ -40,6 +40,11 @@ RSpec.describe Chronicle::ETL::OauthAuthorizer do
     end
     thread.join
     expect(result).to eql({ token: 'abc' })
+  end
+
+  it "raises an exception if flow aborts early" do
+    # TODO: implement this somehow
+    # send signal to sinatra?
   end
 
   def booted?

--- a/spec/chronicle/etl/oauth_authorizer_spec.rb
+++ b/spec/chronicle/etl/oauth_authorizer_spec.rb
@@ -46,13 +46,6 @@ RSpec.describe Chronicle::ETL::OauthAuthorizer do
     # send signal to sinatra?
   end
 
-  context "with custom credential source" do
-    it "raises an exception if namespace does not exist" do
-      expect { authorizer.new(port: port, credentials: 'nonexistent') }
-        .to raise_error(Chronicle::ETL::AuthorizationError)
-    end
-  end
-
   def booted?
     fetch("http://localhost:#{port}/")
     true

--- a/spec/chronicle/etl/oauth_authorizer_spec.rb
+++ b/spec/chronicle/etl/oauth_authorizer_spec.rb
@@ -10,7 +10,6 @@ ENV['APP_ENV'] = 'test'
 # Prevent Launchy from attempt to open windows in oauth_authorizer.rb
 ENV['LAUNCHY_DRY_RUN'] = 'true'
 
-
 RSpec.describe Chronicle::ETL::OauthAuthorizer do
   let(:port) { 5678 }
   let(:authorizer) do
@@ -45,6 +44,13 @@ RSpec.describe Chronicle::ETL::OauthAuthorizer do
   it "raises an exception if flow aborts early" do
     # TODO: implement this somehow
     # send signal to sinatra?
+  end
+
+  context "with custom credential source" do
+    it "raises an exception if namespace does not exist" do
+      expect { authorizer.new(port: port, credentials: 'nonexistent') }
+        .to raise_error(Chronicle::ETL::AuthorizationError)
+    end
   end
 
   def booted?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,17 +5,19 @@ require "bundler/setup"
 require "chronicle/etl"
 require "chronicle/etl/cli"
 
+require_relative "support/capture_io"
 require_relative "support/invoke_cli"
-require_relative "support/run_extraction"
 require_relative "support/mocked_config_directory"
 require_relative "support/mocked_stdin"
+require_relative "support/run_extraction"
+require_relative "support/wait_until"
 
 RSPEC_ROOT = File.dirname(__FILE__)
 
 RSpec.configure do |config|
   config.include Chronicle::ETL::SpecHelpers
-  config.include_context "mocked config directory", :include_shared => true
-  config.include_context "mocked stdin", :include_shared => true
+  config.include_context "mocked config directory", include_shared: true
+  config.include_context "mocked stdin", include_shared: true
 
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -28,29 +30,7 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-
-  # Adapted from minitest
-  # https://github.com/seattlerb/minitest/blob/7d2134a1d386a068f1c7705889c7764a47413861/lib/minitest/assertions.rb#L514
-  def capture
-    require "stringio"
-    orig_stdout = $stdout
-    orig_stderr = $stderr
-
-    captured_stdout = StringIO.new
-    captured_stderr = StringIO.new
-
-    $stdout = captured_stdout
-    $stderr = captured_stderr
-
-    yield
-
-    return captured_stdout.string, captured_stderr.string
-  ensure
-    $stdout = orig_stdout
-    $stderr = orig_stderr
-  end
 end
-
 # This monkeypatch is required because of weird interactions between the
 # `tty-screen` used for CLI output and the way rspec captures stdout
 # see: https://github.com/rspec/rspec-expectations/issues/1305

--- a/spec/support/capture_io.rb
+++ b/spec/support/capture_io.rb
@@ -1,0 +1,44 @@
+module Chronicle
+  module ETL
+    module SpecHelpers
+      # Capture stdout/stderr in a block
+      # Adapted from minitest
+      # https://github.com/seattlerb/minitest/blob/7d2134a1d386a068f1c7705889c7764a47413861/lib/minitest/assertions.rb#L514
+      def capture
+        orig_stdout = $stdout
+        orig_stderr = $stderr
+
+        captured_stdout = StringIO.new
+        captured_stderr = StringIO.new
+
+        $stdout = captured_stdout
+        $stderr = captured_stderr
+
+        yield
+
+        [captured_stdout.string, captured_stderr.string]
+      ensure
+        $stdout = orig_stdout
+        $stderr = orig_stderr
+      end
+
+      # Quick and dirty method to run a block with suppressed stdout/stderr
+      # TODO: refactor this to share code with above
+      def suppress_output
+        orig_stdout = $stdout
+        orig_stderr = $stderr
+
+        captured_stdout = StringIO.new
+        captured_stderr = StringIO.new
+
+        $stdout = captured_stdout
+        $stderr = captured_stderr
+
+        yield
+      ensure
+        $stdout = orig_stdout
+        $stderr = orig_stderr
+      end
+    end
+  end
+end

--- a/spec/support/mock_plugins/chronicle-error/chronicle/error.rb
+++ b/spec/support/mock_plugins/chronicle-error/chronicle/error.rb
@@ -1,0 +1,1 @@
+raise "Plugin can't load"

--- a/spec/support/mock_plugins/chronicle-foo/chronicle/foo.rb
+++ b/spec/support/mock_plugins/chronicle-foo/chronicle/foo.rb
@@ -1,0 +1,1 @@
+require_relative "foo/simple_authorizer"

--- a/spec/support/mock_plugins/chronicle-foo/chronicle/foo/simple_authorizer.rb
+++ b/spec/support/mock_plugins/chronicle-foo/chronicle/foo/simple_authorizer.rb
@@ -1,0 +1,11 @@
+module Chronicle
+  module Foo
+    class SimpleAuthorizer < Chronicle::ETL::Authorizer
+      provider :foo
+
+      def authorize!
+        { token: "abc" }
+      end
+    end
+  end
+end

--- a/spec/support/wait_until.rb
+++ b/spec/support/wait_until.rb
@@ -1,0 +1,17 @@
+module Chronicle
+  module ETL
+    module SpecHelpers
+      # https://stackoverflow.com/questions/19388474/how-can-i-use-sinatra-to-simulate-a-remote-server-in-rspec-vcr
+      def wait_until(timeout = 1)
+        start_time = Time.now
+
+        while true
+          return if yield
+          raise TimeoutError if (Time.now - start_time) > timeout
+
+          sleep(0.1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This works by spinning up a simple Sinatra server with Omniauth running through Rack. A user starts the server through the CLI (`chronicle-etl authorizations:authorize google`) and a browser window is launched for the oauth flow. Upon completion, the server is shut down and the authorization is saved into the secrets system.

- [x] CLI interface
- [x] Authorizer/OauthAuthorizer classes
- [x] OAuth authorization server
- [x] Specs (how to test browser flow?)