### PR TITLE
Implement chronicle-etl plugins:show NAME

### DIFF
--- a/chronicle-etl.gemspec
+++ b/chronicle-etl.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "~> 7.0"
   spec.add_dependency "chronic_duration", "~> 0.10.6"
   spec.add_dependency "colorize", "~> 0.8.1"
+  spec.add_dependency "faraday"
   spec.add_dependency "gems", ">= 1"
   spec.add_dependency "launchy"
   spec.add_dependency "marcel", "~> 1.0.2"
@@ -54,6 +55,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tty-progressbar", "~> 0.17"
   spec.add_dependency "tty-prompt", "~> 0.23"
   spec.add_dependency "tty-spinner"
+  spec.add_dependency "tty-markdown"
   spec.add_dependency "tty-table", "~> 0.11"
   spec.add_dependency "xdg", ">= 4.0"
 

--- a/lib/chronicle/etl/cli/plugins.rb
+++ b/lib/chronicle/etl/cli/plugins.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "faraday"
+require "tty-markdown"
 require "tty-prompt"
 require "tty-spinner"
 
@@ -10,6 +12,13 @@ module Chronicle
       class Plugins < SubcommandBase
         default_task 'list'
         namespace :plugins
+
+        desc "show", "Show information about a plugin"
+        def show(plugin)
+          readme = Chronicle::ETL::Registry::Plugins.readme(plugin)
+          parsed = TTY::Markdown.parse(readme, mode: 16)
+          puts parsed
+        end
 
         desc "install", "Install a plugin"
         def install(*plugins)

--- a/lib/chronicle/etl/registry/plugins.rb
+++ b/lib/chronicle/etl/registry/plugins.rb
@@ -1,3 +1,4 @@
+require 'faraday'
 require 'rubygems'
 require 'rubygems/command'
 require 'rubygems/commands/install_command'
@@ -87,6 +88,14 @@ module Chronicle
         def self.gem_info(name)
           gem_name = "chronicle-#{name}"
           Gems.info(gem_name)
+        end
+
+        # Return readme for a given plugin
+        # @todo make this a responsibility of a Plugin instance
+        def self.readme(name)
+          conn = Faraday.new(url: 'https://raw.githubusercontent.com')
+          response = conn.get("/chronicle-app/chronicle-#{name}/main/README.md")
+          response.body
         end
 
         # Union of installed gems (latest version) + available gems


### PR DESCRIPTION
Simplest idea: displaying parsed README.md in CLI.

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/6291/167727975-5fdd67c3-81c8-4d76-bf91-24272f600b0c.png">

Todos:
- strip out badges
- look into parsing bug for sequence of markdown headers 